### PR TITLE
[Carbon extension] add postinstall script for Pupetter

### DIFF
--- a/extensions/carbon-raycast/package.json
+++ b/extensions/carbon-raycast/package.json
@@ -49,6 +49,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "publish": "ray publish"
+    "publish": "ray publish",
+    "postinstall": "node node_modules/puppeteer/install.js"
   }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/raycast/extensions/issues/10334 https://github.com/raycast/extensions/issues/4140 https://github.com/raycast/extensions/issues/9264 and https://github.com/raycast/extensions/issues/4673

Apologies all, I have been away from the extension for a while. 

I have added a post install script that makes sure Chrome exists for Puppeteer to work for users without chrome installed somehow

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
